### PR TITLE
Fix - Lost events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,9 +68,9 @@ function fetchRequest(context) {
 
 export default class SplunkEvents {
   config(config) {
-    this.events = [];
-    this.pendingEvents = [];
-    this.isSendingEvents = false;
+    this.events = this.events || [];
+    this.pendingEvents = this.pendingEvents || [];
+    this.isSendingEvents = this.isSendingEvents || false;
     this.endpoint = config.endpoint; // required
     this.token = config.token; // required
     this.injectAditionalInfo = config.injectAditionalInfo !== undefined ? config.injectAditionalInfo : false;
@@ -80,9 +80,9 @@ export default class SplunkEvents {
     this.path = config.path !== undefined ? config.path : '/services/collector/event';
     this.host = config.host !== undefined ? config.host : '-';
     this.debug = config.debug !== undefined ? config.debug : false;
-    this.debounceTime = config.debounceTime !== undefined ? config.debounceTime : 2000;
-    this.debouncedFlush = debounce(this.flush, this.debounceTime);
-    this.request = config.request !== undefined ? config.request : fetchRequest;
+    this.debounceTime = config.debounceTime !== undefined ? config.debounceTime : this.debounceTime || 2000;
+    this.debouncedFlush = this.debouncedFlush || debounce(this.flush, this.debounceTime);
+    this.request = config.request !== undefined ? config.request : this.request || fetchRequest;
     this.headers = {
       Authorization: `Splunk ${this.token}`
     };

--- a/src/index.js
+++ b/src/index.js
@@ -181,6 +181,10 @@ export default class SplunkEvents {
       console.log(`sending ${this.pendingEvents.length} events to splunk`);
     }
 
+    if (_this.pendingEvents.length === 0) {
+      return;
+    }
+
     let splunkBatchedFormattedEvents = this.formatEventsForSplunkBatch(this.pendingEvents);
 
     this.request({


### PR DESCRIPTION
# What this PR does?

 - Handle config events sent during logEvent queue (which resets configs and loses events and pendingEvents. Also loses debouncedFlush function reference.)
 - Stops request from happening if pending events queue is empty

# How to test it

 - Send log events and during debounce time call splunkEvents.config passing new configs and watch the magic happening. ✨ 