### PR TITLE
Send the current time to Splunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ splunkEvents.logEvent(
   // Add useful info
   injectAditionalInfo: false, //default
 
+  // Send the current time to Splunk
+  injectTimestamp: false, //default
+
   // Inactive time to wait until flush events. Requires 'autoFlush' option.
   debounceTime: 2000, //default
 
@@ -215,7 +218,7 @@ splunkEvents.config({
         // this authtoken comes from your app's ColossusContext
         'Proxy-Authorization': 'YOUR_AUTH_TOKEN',
         // here you can proxy to https and add ports if you need to
-        'X-Vtex-Proxy-To': `https://${YOUR_SPLUNK_ENDPOINT}:8080`, 
+        'X-Vtex-Proxy-To': `https://${YOUR_SPLUNK_ENDPOINT}:8080`,
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.2.3",
+  "version": "1.3.0-beta.0",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "SplunkEvents.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.3.0",
+  "version": "1.2.3",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "SplunkEvents.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "SplunkEvents.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "SplunkEvents.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "SplunkEvents.js",
   "scripts": {
@@ -34,6 +34,9 @@
     },
     {
       "name": "Alejandro Osorio"
+    },
+    {
+      "name": "Gustavo Rosolem"
     }
   ],
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,7 @@ export default class SplunkEvents {
     let data = {
       sourcetype: this.source,
       host: this.host,
+      time: +new Date(),
       event: parsedEvent
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ export default class SplunkEvents {
     this.debounceTime = config.debounceTime !== undefined ? config.debounceTime : this.debounceTime || 2000;
     this.debouncedFlush = this.debouncedFlush || debounce(this.flush, this.debounceTime);
     this.request = config.request !== undefined ? config.request : this.request || fetchRequest;
+    this.injectTimestamp = config.injectTimestamp !== undefined ? config.injectTimestamp : false;
     this.headers = {
       Authorization: `Splunk ${this.token}`
     };
@@ -107,7 +108,7 @@ export default class SplunkEvents {
     let data = {
       sourcetype: this.source,
       host: this.host,
-      time: +new Date(),
+      ...(this.injectTimestamp && { time: +new Date() }),
       event: parsedEvent
     };
 


### PR DESCRIPTION
When sending the events in batch or due to network latency, it's important to force the current time to send to splunk, allowing to have more precise reports when searching.

Default false to prevent from breaking old integrations.