### PR TITLE
Feature/optional event parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `shouldParseEventData` config
+### Changed
+- Update documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.2] - 2020-04-08
 ### Added
 - New `shouldParseEventData` config
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ splunkEvents.logEvent(
   debounceMaxWait: 5000, //default
 
   // Fetcher to do Splunk Events requests
-  request: `function` with axios signature that uses global Fetch API by default // default (see more details below)
+  request: ({url, method, data, headers, responseType}) => {
+    // a function with the same signature as `axios` that uses global Fetch API by default
+  }, // default (see more details below)
 
   // If the request fail, retry to send events using the debounced flush function
   autoRetryFlush: true, //default

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ splunkEvents.logEvent(
   debounceMaxWait: 5000, //default
 
   // Fetcher to do Splunk Events requests
-  request: function with axios signature that uses global Fetch API by default // default (see more details below)
+  request: `function` with axios signature that uses global Fetch API by default // default (see more details below)
 
   // If the request fail, retry to send events using the debounced flush function
   autoRetryFlush: true, //default
@@ -104,10 +104,13 @@ splunkEvents.logEvent(
 
   // Source of the logs
   source: 'splunkeventsjs', //default
+
+  // Wether or not Splunk Events should parse the event data with the function `parseEventData`
+  shouldParseEventData: true // default
 }
 ```
 
-#### logEvent(level, type, workflowType, workflowInstance, event)
+#### logEvent(level, type, workflowType, workflowInstance, eventData, account)
 
 'level' is the criticality of the event ('Critical','Important','Debug').
 
@@ -117,9 +120,9 @@ splunkEvents.logEvent(
 
 'workflowInstance' defines what id/element is being processed/executed/created in the workflowType.
 
-'event' is an object containing your custom data to send to Splunk. This object should be flat and the properties with 'null' or 'undefined' value will be **omitted**.
+'eventData' is an object containing your custom data to send to Splunk. This object should be flat and properties with a 'null' or 'undefined' value will be **omitted**.
 
-'account' is the accountName (e.g. 'dreamstore','gatewayqa','instoreqa').
+'account' is the `accountName` (e.g. 'dreamstore','gatewayqa','instoreqa').
 
 if 'injectAditionalInfo' is set to true, this function adds some default data to the event
 ```

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     },
     {
       "name": "Gustavo Rosolem"
+    },
+    {
+      "name": "Gabriel Vincent"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "SplunkEvents.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -116,17 +116,18 @@ export default class SplunkEvents {
   ) => {
     this.validateEvent(eventData)
 
-    const event = {
+    const eventObj = {
       level,
       type,
       workflowType,
       workflowInstance,
       account,
-      ...(this.shouldParseEventData
-        ? this.parseEventData(eventData)
-        : eventData),
+      ...eventData,
       ...(this.injectAditionalInfo ? this.getAdditionalInfo() : {}),
     }
+    const event = this.shouldParseEventData
+      ? this.parseEventData(eventObj)
+      : eventObj
 
     let data = {
       sourcetype: this.source,

--- a/src/index.js
+++ b/src/index.js
@@ -97,32 +97,42 @@ export default class SplunkEvents {
         : this.request || fetchRequest
     this.injectTimestamp =
       config.injectTimestamp !== undefined ? config.injectTimestamp : false
+    this.shouldParseEventData =
+      config.shouldParseEventData !== undefined
+        ? config.shouldParseEventData
+        : true
     this.headers = {
       Authorization: `Splunk ${this.token}`,
     }
   }
 
-  logEvent = (level, type, workflowType, workflowInstance, event, account) => {
-    this.validateEvent(event)
-    let parsedEvent = this.parseEventData({
+  logEvent = (
+    level,
+    type,
+    workflowType,
+    workflowInstance,
+    eventData,
+    account
+  ) => {
+    this.validateEvent(eventData)
+
+    const event = {
       level,
       type,
       workflowType,
       workflowInstance,
       account,
-    })
-
-    parsedEvent += this.parseEventData(event)
-
-    if (this.injectAditionalInfo) {
-      parsedEvent += this.getAdditionalInfo()
+      ...(this.shouldParseEventData
+        ? this.parseEventData(eventData)
+        : eventData),
+      ...(this.injectAditionalInfo ? this.getAdditionalInfo() : {}),
     }
 
     let data = {
       sourcetype: this.source,
       host: this.host,
       ...(this.injectTimestamp && { time: +new Date() }),
-      event: parsedEvent,
+      event,
     }
 
     this.events.push(data)


### PR DESCRIPTION
### What is the purpose of this pull request?

This pull request adds a new configuration option that allows the parsing of event data to be skipped, so JSON strings can be sent to Splunk unmodified.