### PR TITLE
Fix infinite loop when logging without custom request fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Infinite loop in flush without custom request function.
 
-## [1.4.0] - 2020-09-17
+## [1.4.0] - 2020-09-17 [YANKED]
 ### Changed
 - Migrate to TypeScript :tada:
 

--- a/src/__tests__/splunk-events.test.ts
+++ b/src/__tests__/splunk-events.test.ts
@@ -1,18 +1,23 @@
-import SplunkEvents from './splunk-events'
+import SplunkEvents from '../splunk-events'
+import { fetchRequest } from '../request'
 
 const SECOND = 1000
+
+jest.mock('../request', () => ({
+  fetchRequest: jest.fn(() => Promise.resolve({} as Response)),
+}))
 
 describe('SplunkEvents', () => {
   let splunkEvents: SplunkEvents
 
   beforeEach(() => {
     jest.useFakeTimers()
-
     splunkEvents = new SplunkEvents()
   })
 
   afterEach(() => {
     jest.runAllTimers()
+    jest.restoreAllMocks()
   })
 
   it('should initialize events', () => {
@@ -140,6 +145,51 @@ describe('SplunkEvents', () => {
         data: expect.stringContaining(
           'workflowInstance=\\"checkout-payment\\"'
         ),
+      })
+    )
+  })
+
+  it('should use request function passed in config', async () => {
+    const request = jest.fn(() => Promise.resolve({} as Response))
+
+    splunkEvents.config({
+      endpoint: '/splunk',
+      token: 'splunk-token-123',
+      request,
+    })
+
+    splunkEvents.logEvent('debug', 'info', 'request', 'defaultRequestImpl', {
+      doesMyRequestSucceed: true,
+    })
+
+    jest.runAllTimers()
+
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.stringContaining('doesMyRequestSucceed=true'),
+      })
+    )
+  })
+
+  it('should default to fetchRequest in case request is not configured', async () => {
+    const requestMock = fetchRequest as jest.Mock
+
+    splunkEvents.config({
+      endpoint: '/splunk',
+      token: 'splunk-token-123',
+    })
+
+    splunkEvents.logEvent('debug', 'info', 'request', 'defaultRequestImpl', {
+      doesDefaultRequestWork: true,
+    })
+
+    jest.runAllTimers()
+
+    expect(requestMock).toHaveBeenCalledTimes(1)
+    expect(requestMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.stringContaining('doesDefaultRequestWork=true'),
       })
     )
   })

--- a/src/splunk-events.ts
+++ b/src/splunk-events.ts
@@ -116,7 +116,7 @@ export default class SplunkEvents {
     this.debounceTime = config.debounceTime ?? this.debounceTime ?? 2000
     this.debouncedFlush =
       this.debouncedFlush ?? debounce(this.flush, this.debounceTime)
-    this._requestImpl = config.request ?? this.request ?? fetchRequest
+    this._requestImpl = config.request ?? this._requestImpl ?? fetchRequest
     this.injectTimestamp = config.injectTimestamp ?? false
     this.shouldParseEventData = config.shouldParseEventData ?? true
     this.headers = {


### PR DESCRIPTION
A typo in the `config` method of the class created an infinite loop when calling the `request` method, because it would end up calling itself without a stop condition. I fixed the typo and added tests to cover this case