### PR TITLE
Add custom header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.2] - 2021-03-09
 ### Added
 - Custom header to be added in the request
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Custom header to be added in the request
 
 ## [1.4.1] - 2020-09-18
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "lib/splunk-events.js",
   "types": "lib/splunk-events.d.ts",

--- a/src/splunk-events.ts
+++ b/src/splunk-events.ts
@@ -126,7 +126,7 @@ export default class SplunkEvents {
     this.shouldParseEventData = config.shouldParseEventData ?? true
     this.headers = {
       Authorization: `Splunk ${this.token}`,
-      'Content-Type': ' application/json',
+      'Content-Type': 'application/json',
       ...config.headers,
     }
   }

--- a/src/splunk-events.ts
+++ b/src/splunk-events.ts
@@ -61,6 +61,11 @@ export interface Config {
    * Token used to authenticate with the Splunk server.
    */
   token: string
+
+  /**
+   * Custom headers to be added in the request
+   */
+  headers?: HeadersInit
 }
 
 type EventData = Record<string, string | number | boolean>
@@ -121,6 +126,7 @@ export default class SplunkEvents {
     this.shouldParseEventData = config.shouldParseEventData ?? true
     this.headers = {
       Authorization: `Splunk ${this.token}`,
+      ...config.headers,
     }
   }
 

--- a/src/splunk-events.ts
+++ b/src/splunk-events.ts
@@ -126,6 +126,7 @@ export default class SplunkEvents {
     this.shouldParseEventData = config.shouldParseEventData ?? true
     this.headers = {
       Authorization: `Splunk ${this.token}`,
+      'Content-Type': ' application/json',
       ...config.headers,
     }
   }


### PR DESCRIPTION
Currently, the `Authorization` header is the only one that we send in the splunk request and this breaks the `logEvent` function in native environments because, differently from a browser, in native we don't send the `Content-type` header as default. This PR has the goal to enable the user to add a custom header in order to keep the `logEvent` working well in different plataforms.