### PR TITLE
CHK-578: Remove content-type from default headers list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed `Content-Type` from default headers list.
 
 ## [1.6.0] - 2021-04-07
 ### Added

--- a/src/splunk-events.ts
+++ b/src/splunk-events.ts
@@ -181,7 +181,6 @@ export default class SplunkEvents {
       config?.maxNumberOfRetries ?? this.maxNumberOfRetries
     this.headers = {
       Authorization: `Splunk ${this.token}`,
-      'Content-Type': 'application/json',
       ...(config?.headers ?? {}),
     }
   }


### PR DESCRIPTION
The addition of this header caused some CORS issues with our Splunk server, due to the header being added to the `Access-Control-Request-Headers` header and the server not including it in the `Access-Control-Allow-Headers` response header.

Also, I think this may have been a mistake, since the payload we send in the request isn't a fully formed JSON in the cases where we batch multiple events in a single request.
