### PR TITLE
Separate debounce and exponential backoff strategies into classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.7.0] - 2021-10-28
 ### Changed
 - Separate debounce and exponential backoff into `Strategy` classes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Separate debounce and exponential backoff into `Strategy` classes.
 
 ## [1.6.1] - 2021-10-26
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-events",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Javascript lib to create Splunk Logs via HTTP",
   "main": "lib/splunk-events.min.js",
   "cdn": "lib/splunk-events.umd.min.js",

--- a/src/__tests__/splunk-events.test.ts
+++ b/src/__tests__/splunk-events.test.ts
@@ -27,17 +27,18 @@ describe('SplunkEvents', () => {
   it('should initialize events', () => {
     expect(splunkEvents).toBeDefined()
     expect(
-      // @ts-expect-error: events is private but we want to
-      // assert on it anyway without making it public
-      splunkEvents.events
-    ).toStrictEqual([])
+      // @ts-expect-error: private property
+      splunkEvents.flushStrategy
+    ).toBeNull()
+
     splunkEvents.config({
       endpoint: 'endpoint',
       token: '',
     })
+
     expect(
-      // @ts-expect-error: same as above
-      splunkEvents.events
+      // @ts-expect-error: private property
+      splunkEvents.flushStrategy.events
     ).toStrictEqual([])
   })
 
@@ -88,145 +89,6 @@ describe('SplunkEvents', () => {
         undefined
       )
     ).toThrowError('Event must not be undefined')
-  })
-
-  describe('Debounce strategy', () => {
-    it('should only make one request if called in timeout range', async () => {
-      splunkEvents.config({
-        endpoint: '/splunk',
-        token: 'splunk-token-123',
-        autoFlush: true,
-        debounceTime: 10 * SECOND,
-      })
-
-      const requestSpy = jest
-        .spyOn(SplunkEvents.prototype, 'request')
-        .mockImplementation(() => Promise.resolve(null))
-
-      splunkEvents.logEvent('debug', 'info', 'checkout', 'checkout-cart', {
-        description: 'User accessed cart page',
-      })
-
-      // advance to half the time of the timeout delay
-      jest.advanceTimersByTime(5 * SECOND)
-
-      splunkEvents.logEvent('debug', 'info', 'checkout', 'checkout-profile', {
-        description: 'User accessed profile step',
-      })
-
-      // wait for timeout to end
-      jest.runAllTimers()
-
-      expect(requestSpy).toHaveBeenCalledTimes(1)
-      expect(requestSpy).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: expect.stringContaining('workflowInstance=\\"checkout-cart\\"'),
-        })
-      )
-      expect(requestSpy).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: expect.stringContaining(
-            'workflowInstance=\\"checkout-profile\\"'
-          ),
-        })
-      )
-
-      await flushPromises()
-
-      // this should be enqueued for 10 seconds from now
-      splunkEvents.logEvent('debug', 'info', 'checkout', 'checkout-payment', {
-        description: 'User accessed payment step',
-      })
-
-      jest.advanceTimersByTime(5 * SECOND)
-
-      expect(requestSpy).toHaveBeenCalledTimes(1)
-
-      jest.advanceTimersByTime(5 * SECOND)
-
-      expect(requestSpy).toHaveBeenCalledTimes(2)
-      expect(requestSpy).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: expect.stringContaining(
-            'workflowInstance=\\"checkout-payment\\"'
-          ),
-        })
-      )
-    })
-
-    it('should update debounce time', async () => {
-      splunkEvents.config({
-        endpoint: '/splunk',
-        token: 'splunk-token-123',
-        debounceTime: 1 * SECOND,
-      })
-
-      const requestSpy = jest
-        .spyOn(SplunkEvents.prototype, 'request')
-        .mockImplementation(() => Promise.resolve(null))
-
-      splunkEvents.logEvent('debug', 'info', 'checkout', 'add-to-cart', {
-        itemId: '320',
-      })
-
-      expect(requestSpy).toHaveBeenCalledTimes(0)
-
-      jest.advanceTimersByTime(1 * SECOND)
-      await flushPromises()
-
-      expect(requestSpy).toHaveBeenCalledTimes(1)
-
-      splunkEvents.config({ debounceTime: 2 * SECOND })
-      splunkEvents.logEvent('debug', 'info', 'checkout', 'update-item', {
-        index: 0,
-        quantity: 10,
-      })
-
-      jest.advanceTimersByTime(1 * SECOND)
-      await flushPromises()
-
-      expect(requestSpy).toHaveBeenCalledTimes(1)
-
-      jest.advanceTimersByTime(1 * SECOND)
-      await flushPromises()
-
-      expect(requestSpy).toHaveBeenCalledTimes(2)
-    })
-
-    it('should use configured debounce time when a request fails', async () => {
-      const requestMock = jest.fn(() => Promise.resolve({} as Response))
-
-      splunkEvents.config({
-        endpoint: '/splunk',
-        token: 'splunk-token-123',
-        debounceTime: 2 * SECOND,
-        autoRetryFlush: true,
-        request: requestMock,
-      })
-
-      requestMock.mockReturnValueOnce(Promise.reject('request failed'))
-
-      splunkEvents.logEvent('debug', 'info', 'request', 'defaultRequestImpl', {
-        doesDefaultRequestWork: true,
-      })
-
-      jest.runOnlyPendingTimers()
-      await flushPromises()
-
-      expect(requestMock).toHaveBeenCalledTimes(1)
-
-      // Skip half of the debounce time
-      jest.advanceTimersByTime(1 * SECOND)
-
-      expect(requestMock).toHaveBeenCalledTimes(1)
-
-      // Skip the remaining of the debounce time
-      jest.advanceTimersByTime(1 * SECOND)
-
-      await flushPromises()
-
-      expect(requestMock).toHaveBeenCalledTimes(2)
-    })
   })
 
   it('should use request function passed in config', async () => {
@@ -299,7 +161,119 @@ describe('SplunkEvents', () => {
     )
   })
 
+  describe('Debounce strategy', () => {
+    it('should only make one request if called in timeout range', async () => {
+      splunkEvents.config({
+        endpoint: '/splunk',
+        token: 'splunk-token-123',
+        autoFlush: true,
+        debounceTime: 10 * SECOND,
+      })
+
+      const requestSpy = jest
+        .spyOn(SplunkEvents.prototype, 'request')
+        .mockImplementation(() => Promise.resolve(null))
+
+      splunkEvents.logEvent('debug', 'info', 'checkout', 'checkout-cart', {
+        description: 'User accessed cart page',
+      })
+
+      // advance to half the time of the timeout delay
+      jest.advanceTimersByTime(5 * SECOND)
+
+      splunkEvents.logEvent('debug', 'info', 'checkout', 'checkout-profile', {
+        description: 'User accessed profile step',
+      })
+
+      // wait for timeout to end
+      jest.runAllTimers()
+
+      expect(requestSpy).toHaveBeenCalledTimes(1)
+      expect(requestSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.stringContaining('workflowInstance=\\"checkout-cart\\"'),
+        })
+      )
+      expect(requestSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.stringContaining(
+            'workflowInstance=\\"checkout-profile\\"'
+          ),
+        })
+      )
+
+      await flushPromises()
+
+      // this should be enqueued for 10 seconds from now
+      splunkEvents.logEvent('debug', 'info', 'checkout', 'checkout-payment', {
+        description: 'User accessed payment step',
+      })
+
+      jest.advanceTimersByTime(5 * SECOND)
+
+      expect(requestSpy).toHaveBeenCalledTimes(1)
+
+      jest.advanceTimersByTime(5 * SECOND)
+
+      expect(requestSpy).toHaveBeenCalledTimes(2)
+      expect(requestSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.stringContaining(
+            'workflowInstance=\\"checkout-payment\\"'
+          ),
+        })
+      )
+    })
+
+    it('should use configured debounce time when a request fails', async () => {
+      const requestMock = jest.fn(() => Promise.resolve({} as Response))
+
+      splunkEvents.config({
+        endpoint: '/splunk',
+        token: 'splunk-token-123',
+        debounceTime: 2 * SECOND,
+        autoRetryFlush: true,
+        request: requestMock,
+      })
+
+      requestMock.mockReturnValueOnce(Promise.reject('request failed'))
+
+      splunkEvents.logEvent('debug', 'info', 'request', 'defaultRequestImpl', {
+        doesDefaultRequestWork: true,
+      })
+
+      jest.runOnlyPendingTimers()
+      await flushPromises()
+
+      expect(requestMock).toHaveBeenCalledTimes(1)
+
+      // Skip half of the debounce time
+      jest.advanceTimersByTime(1 * SECOND)
+
+      expect(requestMock).toHaveBeenCalledTimes(1)
+
+      // Skip the remaining of the debounce time
+      jest.advanceTimersByTime(1 * SECOND)
+
+      await flushPromises()
+
+      expect(requestMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('Exponential backoff', () => {
+    it('should automatically enable auto flush', () => {
+      splunkEvents.config({
+        useExponentialBackoff: true,
+        autoFlush: false,
+      })
+
+      expect(
+        // @ts-expect-error: private property
+        splunkEvents.autoFlush
+      ).toBe(true)
+    })
+
     it('should correctly backoff exponentially', async () => {
       const requestMock = jest
         .fn()
@@ -451,7 +425,7 @@ describe('SplunkEvents', () => {
       expect(requestMock).toHaveBeenCalledTimes(1)
       expect(
         // @ts-expect-error: asserting on private property
-        splunkEvents.isBackoffInProgress
+        splunkEvents.flushStrategy.isBackoffInProgress
       ).toBe(true)
 
       splunkEvents.logEvent(

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,7 +1,12 @@
+export interface DebouncedFn {
+  (): void
+  clear(): void
+}
+
 export default function debounce<T>(
   func: (...args: T[]) => void | Promise<void>,
   wait = 100
-) {
+): DebouncedFn {
   let timeout: NodeJS.Timeout | null = null
   let cancel: (() => void) | null = null
 

--- a/src/debounceStrategy.ts
+++ b/src/debounceStrategy.ts
@@ -1,0 +1,75 @@
+import type { SplunkEvent, Strategy } from './strategy'
+import type { DebouncedFn } from './debounce'
+import debounce from './debounce'
+
+const DEFAULT_DEBOUNCE_TIME = 2_000
+
+export class DebounceStrategy implements Strategy {
+  private pendingEvents: SplunkEvent[] = []
+  private events: SplunkEvent[] = []
+
+  private isSendingEvents = false
+  private flushPending = false
+
+  private autoRetryFlush: boolean
+  private sendEvents: (events: SplunkEvent[]) => Promise<void>
+
+  public flushEvents: DebouncedFn
+
+  constructor({
+    debounceTime = DEFAULT_DEBOUNCE_TIME,
+    autoRetryFlush,
+    sendEvents,
+  }: {
+    debounceTime?: number
+    autoRetryFlush: boolean
+    sendEvents: (events: SplunkEvent[]) => Promise<void>
+  }) {
+    this.flushEvents = debounce(this.flushImpl, debounceTime)
+    this.autoRetryFlush = autoRetryFlush
+    this.sendEvents = sendEvents
+  }
+
+  public abort() {
+    this.flushEvents.clear()
+  }
+
+  public addEvent(event: SplunkEvent) {
+    this.events.push(event)
+  }
+
+  private flushImpl = () => {
+    if (this.isSendingEvents) {
+      this.flushPending = true
+
+      return
+    }
+
+    this.pendingEvents = Array.from(this.events)
+    this.events = []
+    this.isSendingEvents = true
+
+    this.sendEvents(this.pendingEvents)
+      .then(() => {
+        this.pendingEvents = []
+        this.isSendingEvents = false
+
+        if (!this.flushPending) {
+          return
+        }
+
+        this.flushPending = false
+
+        return this.flushImpl()
+      })
+      .catch(() => {
+        this.events = this.events.concat(this.pendingEvents)
+        this.pendingEvents = []
+        this.isSendingEvents = false
+
+        if (this.autoRetryFlush) {
+          this.flushEvents()
+        }
+      })
+  }
+}

--- a/src/exponentialBackoffStrategy.ts
+++ b/src/exponentialBackoffStrategy.ts
@@ -1,0 +1,80 @@
+import type { Strategy, SplunkEvent } from './strategy'
+
+const DEFAULT_EXPONENTIAL_BACKOFF_LIMIT = 60_000
+
+export class ExponentialBackoffStrategy implements Strategy {
+  private isBackoffInProgress = false
+  private maxNumberOfRetries = Infinity
+
+  private events: SplunkEvent[] = []
+  private pendingEvents: SplunkEvent[] = []
+  private exponentialBackoffLimit: number
+
+  private sendEvents: (events: SplunkEvent[]) => Promise<void>
+
+  constructor({
+    sendEvents,
+    exponentialBackoffLimit = DEFAULT_EXPONENTIAL_BACKOFF_LIMIT,
+    maxNumberOfRetries,
+  }: {
+    sendEvents: (events: SplunkEvent[]) => Promise<void>
+    exponentialBackoffLimit?: number
+    maxNumberOfRetries?: number
+  }) {
+    this.sendEvents = sendEvents
+    this.exponentialBackoffLimit = exponentialBackoffLimit
+    this.maxNumberOfRetries = maxNumberOfRetries ?? this.maxNumberOfRetries
+  }
+
+  public addEvent(event: SplunkEvent) {
+    this.events.push(event)
+  }
+
+  public flushEvents(): Promise<void> {
+    if (this.isBackoffInProgress) {
+      return Promise.resolve()
+    }
+
+    this.isBackoffInProgress = true
+
+    const backoffMultiplier = 2
+
+    const executeFlush = (depth = 0): Promise<void> => {
+      this.pendingEvents = this.pendingEvents.concat(this.events)
+
+      this.events = []
+
+      return this.sendEvents(this.pendingEvents)
+        .then(() => {
+          this.pendingEvents = []
+          this.isBackoffInProgress = false
+
+          if (this.events.length > 0) {
+            return this.flushEvents()
+          }
+
+          return Promise.resolve()
+        })
+        .catch(() => {
+          const waitTime = backoffMultiplier ** depth * 1_000
+
+          if (depth > this.maxNumberOfRetries) {
+            this.events = []
+            this.isBackoffInProgress = false
+
+            return
+          }
+
+          return new Promise((resolve, reject) => {
+            setTimeout(() => {
+              executeFlush(depth + 1)
+                .then(resolve, reject)
+                .catch(reject)
+            }, Math.min(waitTime, this.exponentialBackoffLimit))
+          })
+        })
+    }
+
+    return executeFlush()
+  }
+}

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -1,0 +1,13 @@
+export type EventData = Record<string, string | number | boolean>
+
+export type SplunkEvent = {
+  host: string
+  sourcetype: string
+  time?: number
+  event: EventData | string
+}
+
+export interface Strategy {
+  addEvent(event: SplunkEvent): void
+  flushEvents(): void
+}


### PR DESCRIPTION
Creates a new interface called `Strategy` to concentrate the logic for retrying the request after failing the flush operation. This is just a tech debt improvement as the previous code was really hard to read with mixed logic for debouncing and exponential backoff in the same class, and no clear difference which properties/methods belonged to whom.